### PR TITLE
fix(variants): copy local function-plugin row files into generated variants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@
 
 import { Context } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
-import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
@@ -296,6 +296,21 @@ interface AgentPresetsService {
  * @param shellPath - absolute path of the plugin's built WSL shell provider.
  * @param fsPath - absolute path of the plugin's built WSL fs provider.
  */
+/**
+ * Relative './x.mjs' row files a composition references. Local function-plugin
+ * rows travel with their preset directory; generated variants must copy them
+ * along or the variant composition fails to load.
+ * @param composition - the composition text.
+ */
+function localRowFiles(composition: string): Set<string> {
+  const files = new Set<string>()
+  for (const line of composition.split('\n')) {
+    const match = /^\s*name:\s*['"]?(\.\/[^'"]+\.m?js)['"]?\s*$/.exec(line)
+    if (match?.[1] !== undefined) files.add(match[1])
+  }
+  return files
+}
+
 async function materializeVariants(
   agentPresets: AgentPresetsService,
   dshHome: string,
@@ -314,6 +329,34 @@ async function materializeVariants(
     const dir = join(userRoot, variantId)
     mkdirSync(dir, { recursive: true })
     writeFileSync(join(dir, 'agent.cordis.yml'), transformed, 'utf8')
+    // Copy local function-plugin row files (name: './x.mjs') from the source
+    // preset into the variant directory, including their transitive relative
+    // imports — the variant composition references them relatively and they
+    // must travel with it, or the variant fails to load at mount time.
+    const pending = [...localRowFiles(transformed)]
+    const visited = new Set<string>()
+    while (pending.length > 0) {
+      const rowFile = pending.pop()
+      if (rowFile === undefined || visited.has(rowFile)) continue
+      visited.add(rowFile)
+      const srcFile = join(dirname(preset.path), rowFile)
+      if (!existsSync(srcFile)) continue
+      mkdirSync(dirname(join(dir, rowFile)), { recursive: true })
+      copyFileSync(srcFile, join(dir, rowFile))
+      try {
+        const content = readFileSync(srcFile, 'utf8')
+        const importRe = /(?:from\s+|import\s*\(\s*|require\s*\(\s*)['"](\.\/[^'"]+)['"]/g
+        let match: RegExpExecArray | null
+        while ((match = importRe.exec(content)) !== null) {
+          let spec = match[1]
+          if (!/\.m?js$/.test(spec)) spec += '.mjs'
+          pending.push(spec)
+        }
+      } catch {
+        // Unreadable row file: keep whatever was copied; the variant reports
+        // the failure through the roster when mounted.
+      }
+    }
     const labels = MODE_DISPLAY_LABELS[preset.id]
     let name = variantName(preset.id, preset.id)
     let orderLine = ''


### PR DESCRIPTION
## 问题变体生成器只写 \gent.cordis.yml\ + \preset.yml\，但组合里 \
ame: './x.mjs'\ 的本地函数插件行是**相对路径**——文件不随变体走，变体挂载即失败。实锤：带 \./router-bootstrap.mjs\ 行的源预设，其生成的 wsl- 变体目录里没有该文件（且该文件还 import \./router-core.mjs\，传递依赖同样缺失）。## 方案生成变体时：1. 从转换后组合提取本地行文件（\
ame: './x.mjs'\ 正则）2. BFS 复制：每个已复制文件内的相对 import（from/import()/require）继续复制（无扩展名补 .mjs）3. 源不存在/不可读时跳过，不影响其他变体生成## 变更1 文件 +44/-1（node:fs 导入 + localRowFiles 助手 + 复制循环）## 验证- 实机：修复后 \wsl-minimal-gray\（tool-bootstrap.mjs + compaction-epoch.mjs）与 \wsl-router-standard\（router-bootstrap.mjs + router-core.mjs）文件齐全- \
ode --experimental-strip-types --check\ 通过；热重载后变体正常生成